### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -5,12 +5,11 @@ name: Browser Tests
 # **Who does it impact**: Docs engineering, open-source engineering contributors.
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   push:
     branches:
       - main
-  pull_request:
-
+  pull_request: null
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,6 +23,7 @@ jobs:
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/dry-run-sync-algolia-search-indices.yml
+++ b/.github/workflows/dry-run-sync-algolia-search-indices.yml
@@ -5,8 +5,7 @@ name: (Dry run) Algolia
 # **Who does it impact**: Docs engineering.
 
 on:
-  workflow_dispatch:
-
+  workflow_dispatch: null
 jobs:
   updateIndices:
     name: (Dry run) Update indices
@@ -18,6 +17,7 @@ jobs:
       - uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
       - name: cache node modules
         uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
         with:

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -5,12 +5,11 @@ name: Lint JS
 # **Who does it impact**: Docs engineering, open-source engineering contributors.
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   push:
     branches:
       - main
-  pull_request:
-
+  pull_request: null
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -22,6 +21,7 @@ jobs:
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/link-check-dotcom.yml
+++ b/.github/workflows/link-check-dotcom.yml
@@ -1,19 +1,20 @@
-name: 'Link Checker: Dotcom'
+name: "Link Checker: Dotcom"
 
 # **What it does**: This checks links for dotcom version of docs.
 # **Why we have it**: We want to know if links break.
 # **Who does it impact**: Docs content.
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   push:
     branches:
       - main
-  pull_request:
-
+  pull_request: null
 jobs:
   build:
-    runs-on: ${{ fromJson('["ubuntu-latest", "self-hosted"]')[github.repository == 'github/docs-internal'] }}
+    runs-on:
+      ${{ fromJson('["ubuntu-latest", "self-hosted"]')[github.repository ==
+      'github/docs-internal'] }}
     steps:
       # Each of these ifs needs to be repeated at each step to make sure the required check still runs
       # Even if if doesn't do anything
@@ -24,6 +25,7 @@ jobs:
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Install
         run: npm ci
@@ -31,7 +33,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: 'Link check: Dotcom'
+      - name: "Link check: Dotcom"
         env:
-          DOCS_VERSION: 'dotcom'
+          DOCS_VERSION: "dotcom"
         run: npm run link-check

--- a/.github/workflows/link-check-ghae.yml
+++ b/.github/workflows/link-check-ghae.yml
@@ -1,19 +1,20 @@
-name: 'Link Checker: GitHub AE'
+name: "Link Checker: GitHub AE"
 
 # **What it does**: This checks links for GHAE version of docs.
 # **Why we have it**: We want to know if links break.
 # **Who does it impact**: Docs content.
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   push:
     branches:
       - main
-  pull_request:
-
+  pull_request: null
 jobs:
   build:
-    runs-on: ${{ fromJson('["ubuntu-latest", "self-hosted"]')[github.repository == 'github/docs-internal'] }}
+    runs-on:
+      ${{ fromJson('["ubuntu-latest", "self-hosted"]')[github.repository ==
+      'github/docs-internal'] }}
     steps:
       # Each of these ifs needs to be repeated at each step to make sure the required check still runs
       # Even if if doesn't do anything
@@ -24,6 +25,7 @@ jobs:
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Install
         run: npm ci
@@ -31,7 +33,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: 'Link check: GitHub AE'
+      - name: "Link check: GitHub AE"
         env:
-          DOCS_VERSION: 'github-ae'
+          DOCS_VERSION: "github-ae"
         run: npm run link-check

--- a/.github/workflows/link-check-ghes.yml
+++ b/.github/workflows/link-check-ghes.yml
@@ -1,19 +1,20 @@
-name: 'Link Checker: Enterprise Server'
+name: "Link Checker: Enterprise Server"
 
 # **What it does**: This checks links for GHES version of docs.
 # **Why we have it**: We want to know if links break.
 # **Who does it impact**: Docs content.
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   push:
     branches:
       - main
-  pull_request:
-
+  pull_request: null
 jobs:
   build:
-    runs-on: ${{ fromJson('["ubuntu-latest", "self-hosted"]')[github.repository == 'github/docs-internal'] }}
+    runs-on:
+      ${{ fromJson('["ubuntu-latest", "self-hosted"]')[github.repository ==
+      'github/docs-internal'] }}
     steps:
       # Each of these ifs needs to be repeated at each step to make sure the required check still runs
       # Even if if doesn't do anything
@@ -24,6 +25,7 @@ jobs:
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Install
         run: npm ci
@@ -31,7 +33,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: 'Link check: Enterprise Server'
+      - name: "Link check: Enterprise Server"
         env:
-          DOCS_VERSION: 'enterprise-server'
+          DOCS_VERSION: "enterprise-server"
         run: npm run link-check

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -5,12 +5,13 @@ name: Pa11y
 # **Who does it impact**: Docs engineering, users who need accessibility features.
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   schedule:
-    - cron: '25 17 * * *' # once a day at 17:25 UTC / 11:50 PST
+    - cron: "25 17 * * *" # once a day at 17:25 UTC / 11:50 PST
 jobs:
   test:
-    if: github.repository == 'github/docs-internal' || github.repository == 'github/docs'
+    if: github.repository == 'github/docs-internal' || github.repository ==
+      'github/docs'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -20,6 +21,7 @@ jobs:
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/staging-deploy-pr.yml
+++ b/.github/workflows/staging-deploy-pr.yml
@@ -14,17 +14,18 @@ on:
   workflow_dispatch:
     inputs:
       pullRequestUrl:
-        description: 'Pull Request URL'
+        description: "Pull Request URL"
         required: true
-        default: 'https://github.com/github/docs/pull/1234'
+        default: "https://github.com/github/docs/pull/1234"
       forceRebuild:
-        description: 'Force the Heroku App to be rebuilt from scratch? (true/false)'
+        description: "Force the Heroku App to be rebuilt from scratch? (true/false)"
         required: false
-        default: 'false'
+        default: "false"
 
 jobs:
   validate-inputs:
-    if: ${{ github.repository == 'github/docs-internal' || github.repository == 'github/docs' }}
+    if: ${{ github.repository == 'github/docs-internal' || github.repository ==
+      'github/docs' }}
     name: Validate inputs
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -36,13 +37,14 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           # Enables cloning the Early Access repo later with the relevant PAT
-          persist-credentials: 'false'
+          persist-credentials: "false"
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         name: Setup node
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         name: Get npm cache directory
@@ -95,7 +97,8 @@ jobs:
             core.setOutput('headRef', pullRequest.head.ref)
 
   deploy:
-    if: ${{ github.repository == 'github/docs-internal' || github.repository == 'github/docs' }}
+    if: ${{ github.repository == 'github/docs-internal' || github.repository ==
+      'github/docs' }}
     needs: validate-inputs
     name: Deploy
     runs-on: ubuntu-latest
@@ -108,12 +111,13 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           # Enables cloning the Early Access repo later with the relevant PAT
-          persist-credentials: 'false'
+          persist-credentials: "false"
 
       - name: Setup node
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/staging-undeploy-pr.yml
+++ b/.github/workflows/staging-undeploy-pr.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   undeploy:
-    if: ${{ github.repository == 'github/docs-internal' || github.repository == 'github/docs' }}
+    if: ${{ github.repository == 'github/docs-internal' || github.repository ==
+      'github/docs' }}
     name: Undeploy
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -24,12 +25,13 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           # Enables cloning the Early Access repo later with the relevant PAT
-          persist-credentials: 'false'
+          persist-credentials: "false"
 
       - name: Setup node
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/sync-algolia-search-indices.yml
+++ b/.github/workflows/sync-algolia-search-indices.yml
@@ -5,7 +5,7 @@ name: Algolia
 # **Who does it impact**: Anyone using search on docs.
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   push:
     branches:
       - main
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
       - name: cache node modules
         uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
         with:
@@ -45,4 +46,6 @@ jobs:
           channel: ${{ secrets.DOCS_ALERTS_SLACK_CHANNEL_ID }}
           bot-token: ${{ secrets.SLACK_DOCS_BOT_TOKEN }}
           color: failure
-          text: The last Algolia workflow run for ${{github.repository}} failed. Search actions for `workflow:Algolia`
+          text:
+            The last Algolia workflow run for ${{github.repository}} failed. Search
+            actions for `workflow:Algolia`

--- a/.github/workflows/sync-single-english-algolia-index.yml
+++ b/.github/workflows/sync-single-english-algolia-index.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
       - name: cache node modules
         uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
         with:
@@ -36,14 +37,16 @@ jobs:
             ${{ runner.os }}-node-
       - name: npm ci
         run: npm ci
-      - name: Get version from Algolia label if present; only continue if the label is found.
+      - name:
+          Get version from Algolia label if present; only continue if the label is
+          found.
         id: getVersion
         run: $GITHUB_WORKSPACE/.github/actions-scripts/enterprise-algolia-label.js
       - if: ${{ steps.getVersion.outputs.versionToSync }}
         name: Sync English index for single version
         env:
           VERSION: ${{ steps.getVersion.outputs.versionToSync }}
-          LANGUAGE: 'en'
+          LANGUAGE: "en"
           ALGOLIA_APPLICATION_ID: ${{ secrets.ALGOLIA_APPLICATION_ID }}
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -7,10 +7,10 @@ name: Node.js Tests - Windows
 # **Who does it impact**: Anyone working on docs on a Windows device.
 
 on:
-  workflow_dispatch:
-  pull_request:
+  workflow_dispatch: null
+  pull_request: null
   schedule:
-    - cron: '50 19 * * *' # once a day at 19:50 UTC / 11:50 PST
+    - cron: "50 19 * * *" # once a day at 19:50 UTC / 11:50 PST
 
 env:
   CI: true
@@ -18,7 +18,10 @@ env:
 jobs:
   test:
     runs-on: windows-latest
-    if: (github.event_name != 'pull_request') || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'Windows') || contains(github.event.pull_request.labels.*.name, 'windows')))
+    if: (github.event_name != 'pull_request') || (github.event_name ==
+      'pull_request' && (contains(github.event.pull_request.labels.*.name,
+      'Windows') || contains(github.event.pull_request.labels.*.name,
+      'windows')))
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -29,12 +32,13 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           # Enables cloning the Early Access repo later with the relevant PAT
-          persist-credentials: 'false'
+          persist-credentials: "false"
 
       - name: Setup node
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Get npm cache directory
         id: npm-cache
@@ -66,4 +70,4 @@ jobs:
       - name: Run tests
         run: npx jest tests/${{ matrix.test-group }}/
         env:
-          NODE_OPTIONS: '--max_old_space_size=8192'
+          NODE_OPTIONS: "--max_old_space_size=8192"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,11 @@ name: Node.js Tests
 # **Who does it impact**: Docs engineering, open-source engineering contributors.
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   push:
     branches:
       - main
-  pull_request:
-
+  pull_request: null
 env:
   CI: true
 
@@ -20,7 +19,9 @@ jobs:
   test:
     # Run on self-hosted if the private repo or ubuntu-latest if the public repo
     # See pull # 17442 in the private repo for context
-    runs-on: ${{ fromJson('["ubuntu-latest", "self-hosted"]')[github.repository == 'github/docs-internal'] }}
+    runs-on:
+      ${{ fromJson('["ubuntu-latest", "self-hosted"]')[github.repository ==
+      'github/docs-internal'] }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -34,12 +35,13 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           # Enables cloning the Early Access repo later with the relevant PAT
-          persist-credentials: 'false'
+          persist-credentials: "false"
 
       - name: Setup node
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Get npm cache directory
         id: npm-cache
@@ -71,4 +73,4 @@ jobs:
       - name: Run tests
         run: npx jest tests/${{ matrix.test-group }}/
         env:
-          NODE_OPTIONS: '--max_old_space_size=8192'
+          NODE_OPTIONS: "--max_old_space_size=8192"

--- a/.github/workflows/yml-lint.yml
+++ b/.github/workflows/yml-lint.yml
@@ -5,17 +5,17 @@ name: Lint Yaml
 # **Who does it impact**: Docs engineering, docs content.
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   push:
     branches:
       - main
     paths:
-      - '**/*.yml'
-      - '**/*.yaml'
+      - "**/*.yml"
+      - "**/*.yaml"
   pull_request:
     paths:
-      - '**/*.yml'
-      - '**/*.yaml'
+      - "**/*.yml"
+      - "**/*.yaml"
 
 jobs:
   lint:
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Get npm cache directory
         id: npm-cache


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
